### PR TITLE
[BISERVER-14727] Update versions

### DIFF
--- a/pax-logging-api-wrap/pom.xml
+++ b/pax-logging-api-wrap/pom.xml
@@ -11,7 +11,7 @@
 
   <artifactId>pax-logging-api-wrap</artifactId>
   <!-- We are mirroring the wrapped version of pax logging -->
-  <version>1.11.12</version>
+  <version>1.10.9</version>
   <packaging>bundle</packaging>
 
   <description>
@@ -23,8 +23,7 @@
   <properties>
     <!-- When eventually upgrading this version, take care of also verifying and updating if needed
          the manifest configuration bellow. -->
-    <pax-logging-api.version>1.11.12</pax-logging-api.version>
-    <log4j.version>2.17.0</log4j.version>
+    <pax-logging-api.version>1.10.9</pax-logging-api.version>
   </properties>
 
   <dependencies>
@@ -70,34 +69,40 @@
             <Bundle-Activator>org.ops4j.pax.logging.internal.Activator</Bundle-Activator>
 
             <Export-Package>
-              org.apache.avalon.framework.logger;-split-package:=merge-first; version=4.3; provider=paxlogging,
-              org.apache.juli.logging; version=5.5.28; provider=paxlogging,
-              org.apache.juli.logging; version=6.0.18; provider=paxlogging,
-              org.apache.logging.log4j; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.message; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.simple; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.spi; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.status; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.util; version=${log4j.version}; provider=paxlogging,
-              org.knopflerfish.service.log; version=1.1.0; provider=paxlogging,
-              org.ops4j.pax.logging; version=${pax-logging-api.version}; provider=paxlogging,
-              org.ops4j.pax.logging.avalon; version=${pax-logging-api.version}; provider=paxlogging,
-              org.ops4j.pax.logging.slf4j; version=${pax-logging-api.version}; provider=paxlogging,
-              org.ops4j.pax.logging.spi; version=${pax-logging-api.version}; provider=paxlogging,
-              org.osgi.service.log; version=1.3;-split-package:=merge-first,
-              org.jboss.logging; version=3.3.0.Final; provider=paxlogging
+              org.apache.avalon.framework.logger;version="4.3";provider=paxlogging;uses:="org.apache.log",
+              org.apache.juli.logging;version="5.5.28";provider=paxlogging;uses:="org.osgi.framework",
+              org.apache.logging.log4j;version="2.8.1";provider=paxlogging;uses:="org.apache.logging.log4j.message,org.apache.logging.log4j.spi,org.apache.logging.log4j.util",
+              org.apache.logging.log4j.message;version="2.8.1";provider=paxlogging;uses:="org.apache.logging.log4j.util",
+              org.apache.logging.log4j.simple;version="2.8.1";provider=paxlogging;uses:="org.apache.logging.log4j,org.apache.logging.log4j.message,org.apache.logging.log4j.spi,org.apache.logging.log4j.util",
+              org.apache.logging.log4j.spi;version="2.8.1";provider=paxlogging;uses:="org.apache.logging.log4j,org.apache.logging.log4j.message,org.apache.logging.log4j.util",
+              org.apache.logging.log4j.status;version="2.8.1";provider=paxlogging;uses:="org.apache.logging.log4j,org.apache.logging.log4j.message,org.apache.logging.log4j.spi",
+              org.apache.logging.log4j.util;version="2.8.1";provider=paxlogging;uses:="org.apache.logging.log4j.message,org.apache.logging.log4j.spi,org.osgi.framework",
+              org.knopflerfish.service.log;version="1.1.0";provider=paxlogging;uses:="org.osgi.framework,org.osgi.service.log",
+              org.ops4j.pax.logging;version="1.10.9";provider=paxlogging;uses:="org.knopflerfish.service.log,org.osgi.framework,org.osgi.service.log,org.osgi.util.tracker",
+              org.ops4j.pax.logging.avalon;version="1.10.9";provider=paxlogging;uses:="org.apache.avalon.framework.logger,org.ops4j.pax.logging,org.osgi.framework",
+              org.ops4j.pax.logging.slf4j;version="1.10.9";provider=paxlogging;uses:="org.ops4j.pax.logging,org.osgi.framework",
+              org.ops4j.pax.logging.spi;version="1.10.9";provider=paxlogging,
+              org.osgi.service.log;version="1.3";uses:="org.osgi.framework",
+              org.jboss.logging;version="3.3.0.Final";provider=paxlogging,
+              org.apache.juli.logging;version="6.0.18";provider=paxlogging,
+              org.apache.logging.log4j;version="2.12.4";provider=paxlogging,
+              org.apache.logging.log4j.message;version="2.12.4";provider=paxlogging,
+              org.apache.logging.log4j.simple;version="2.12.4";provider=paxlogging,
+              org.apache.logging.log4j.spi;version="2.12.4";provider=paxlogging,
+              org.apache.logging.log4j.status;version="2.12.4";provider=paxlogging,
+              org.apache.logging.log4j.util;version="2.12.4";provider=paxlogging
             </Export-Package>
 
             <Import-Package>
-              org.osgi.framework; version="[1.0.0,2.0.0)",
-              org.osgi.framework.wiring; version="[1.0.0,2.0.0)",
-              org.osgi.util.tracker; version="[1.0.0,2.0.0)",
-              org.ops4j.pax.logging; version="[0.9.5,2.0.0)",
-              org.ops4j.pax.logging.avalon; version="[0.9.5,2.0.0)",
-              org.osgi.service.event; version="[1.0.0,2.0.0)"; resolution:=optional,
-              org.osgi.service.log; version="[1.3.0,2.0.0)",
-              org.apache.log; resolution:=optional,
               javax.xml.parsers,
+              org.ops4j.pax.logging;version="[0.9.5,2.0.0)",
+              org.ops4j.pax.logging.avalon;version="[0.9.5,2.0.0)",
+              org.osgi.framework;version="[1.0.0,2.0.0)",
+              org.osgi.framework.wiring;version="[1.0.0,2.0.0)",
+              org.osgi.util.tracker;version="[1.0.0,2.0.0)",
+              org.osgi.service.event;version="[1.0.0,2.0.0)";resolution:=optional,
+              org.osgi.service.log;version="[1.3.0,2.0.0)",
+              org.apache.log;resolution:=optional,
               org.w3c.dom
             </Import-Package>
           </instructions>


### PR DESCRIPTION
To use log4j2 **2.17.1** and mimic pax-logging-api **1.11.13**

@andreramos89 