### PR TITLE
[BISERVER-14720] - Upgrade Log4j2 - pax-logging 1.11.13 and log4j2 2.…

### DIFF
--- a/pax-logging-api-wrap/pom.xml
+++ b/pax-logging-api-wrap/pom.xml
@@ -16,7 +16,8 @@
   <description>
     This OSGi bundle wraps the org.ops4j.pax.logging/pax-logging-api bundle preventing it
     from exporting packages from the logging APIs the Pentaho products use and inject from
-    the main classloader (org.apache.commons.logging, org.apache.log4j and org.slf4j).
+    the main classloader (org.apache.commons.logging, org.apache.log4j, org.apache.logging.log4j
+    and org.slf4j).
   </description>
 
   <properties>
@@ -57,11 +58,12 @@
             <Bundle-Version>${project.version}</Bundle-Version>
 
             <!--
-              Configurations taken from:
-                https://github.com/ops4j/org.ops4j.pax.logging/blob/logging-1.10.2/pax-logging-api/osgi.bnd
+              Configurations based on:
+                https://github.com/ops4j/org.ops4j.pax.logging/blob/logging-1.11.13/pax-logging-api/osgi.bnd
+              And MANIFEST.MF from an official pax-logging-api version 1.11.13
 
-              Removed any exports of the org.apache.commons.logging, org.apache.log4j and org.slf4j packages
-              and sub-packages.
+              Removed any exports of the org.apache.commons.logging, org.apache.log4j, org.apache.logging.log4j
+              and org.slf4j packages and sub-packages.
 
               Recheck and update them when upgrading the pax-logging-api version.
             -->
@@ -69,22 +71,21 @@
             <Bundle-Activator>org.ops4j.pax.logging.internal.Activator</Bundle-Activator>
 
             <Export-Package>
-              org.apache.avalon.framework.logger;-split-package:=merge-first; version=4.3; provider=paxlogging,
-              org.apache.juli.logging; version=5.5.28; provider=paxlogging,
-              org.apache.juli.logging; version=6.0.18; provider=paxlogging,
-              org.apache.logging.log4j; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.message; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.simple; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.spi; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.status; version=${log4j.version}; provider=paxlogging,
-              org.apache.logging.log4j.util; version=${log4j.version}; provider=paxlogging,
-              org.knopflerfish.service.log; version=1.1.0; provider=paxlogging,
-              org.ops4j.pax.logging; version=${pax-logging-api.version}; provider=paxlogging,
-              org.ops4j.pax.logging.avalon; version=${pax-logging-api.version}; provider=paxlogging,
-              org.ops4j.pax.logging.slf4j; version=${pax-logging-api.version}; provider=paxlogging,
-              org.ops4j.pax.logging.spi; version=${pax-logging-api.version}; provider=paxlogging,
-              org.osgi.service.log; version=1.3;-split-package:=merge-first,
-              org.jboss.logging; version=3.3.0.Final; provider=paxlogging
+              org.apache.avalon.framework.logger;uses:="org.apache.log";provider=paxlogging;version="4.3",
+              org.apache.juli.logging;uses:="org.ops4j.pax.logging";provider=paxlogging;version="9.0.27",
+              org.apache.juli.logging;provider=paxlogging;version="8.5.40",
+              org.apache.juli.logging;provider=paxlogging;version="7.0.94",
+              org.apache.juli.logging;provider=paxlogging;version="6.0.18",
+              org.apache.juli.logging;provider=paxlogging;version="5.5.28",
+              org.jboss.logging;provider=paxlogging;version="3.4.1.Final",
+              org.jboss.logging;provider=paxlogging;version="3.3.0.Final",
+              org.knopflerfish.service.log;uses:="org.osgi.framework,org.osgi.service.log";provider=paxlogging;version="1.2.0",
+              org.knopflerfish.service.log;provider=paxlogging;version="1.1.0",
+              org.ops4j.pax.logging;uses:="org.knopflerfish.service.log,org.osgi.framework,org.osgi.service.log,org.osgi.util.tracker";provider=paxlogging;version="1.11.13",
+              org.ops4j.pax.logging.avalon;uses:="org.apache.avalon.framework.logger,org.ops4j.pax.logging";provider=paxlogging;version="1.11.13",
+              org.ops4j.pax.logging.slf4j;uses:="org.ops4j.pax.logging";provider=paxlogging;version="1.11.13",
+              org.ops4j.pax.logging.spi;provider=paxlogging;version="1.11.13",
+              org.osgi.service.log;uses:="org.osgi.framework";version="1.3"
             </Export-Package>
 
             <Import-Package>


### PR DESCRIPTION
…17.1

I've synchronized the "Export-Package" section with the MANIFEST from the official pax-logging-api (version 1.11.13).
This was needed because using the original source code did not had the same deduplication behaviour as the official jar had.

I've also added a second change: remove 'org.apache.logging.log4j' package/sub-packages as it is the same case as the other removed packages (as explained on the description section).

@rmansoor @andreramos89 @peterrinehart 