### PR TITLE
fix[PPP-6425]: update pax-logging version to 2.2.12

### DIFF
--- a/pax-logging-api-wrap/pom.xml
+++ b/pax-logging-api-wrap/pom.xml
@@ -10,7 +10,7 @@
 
   <artifactId>pax-logging-api-wrap</artifactId>
   <!-- We are mirroring the wrapped version of pax logging -->
-  <version>2.2.7</version>
+  <version>2.2.12</version>
   <packaging>bundle</packaging>
 
   <description>
@@ -22,9 +22,8 @@
 
   <properties>
     <!-- When eventually upgrading this version, take care of also verifying and updating if needed
-         the manifest configuration bellow. -->
-    <pax-logging-api.version>2.2.7</pax-logging-api.version>
-    <log4j.version>2.17.1</log4j.version>
+         the manifest configuration below. -->
+    <pax-logging-api.version>2.2.12</pax-logging-api.version>
   </properties>
 
   <dependencies>
@@ -61,8 +60,8 @@
 
             <!--
               Configurations based on:
-                https://github.com/ops4j/org.ops4j.pax.logging/blob/logging-2.2.7/pax-logging-api/osgi.bnd
-              And MANIFEST.MF from an official pax-logging-api version 2.2.7
+                https://github.com/ops4j/org.ops4j.pax.logging/blob/logging-2.2.12/pax-logging-api/osgi.bnd
+              And MANIFEST.MF from an official pax-logging-api version 2.2.12
 
               Removed any exports of the org.apache.commons.logging, org.apache.log4j, org.apache.logging.log4j
               and org.slf4j packages and sub-packages.
@@ -74,21 +73,26 @@
             <Bundle-Activator>org.ops4j.pax.logging.internal.Activator</Bundle-Activator>
 
             <Export-Package>
-              org.ops4j.pax.logging.slf4j;uses:="org.ops4j.pax.logging";provider=paxlogging;version="2.2.7",
-              org.apache.juli.logging;uses:="org.ops4j.pax.logging";provider=paxlogging;version="9.0.27",
+              org.ops4j.pax.logging.slf4j;uses:="org.ops4j.pax.logging";provider=paxlogging;version="2.2.12",
+              org.apache.juli.logging;uses:="org.ops4j.pax.logging";provider=paxlogging;version="11.0",
+              org.apache.juli.logging;provider=paxlogging;version="10.1",
+              org.apache.juli.logging;provider=paxlogging;version="10.0",
+              org.apache.juli.logging;provider=paxlogging;version="9.0.117",
               org.apache.juli.logging;provider=paxlogging;version="8.5.40",
               org.apache.juli.logging;provider=paxlogging;version="7.0.94",
               org.apache.juli.logging;provider=paxlogging;version="6.0.18",
               org.apache.juli.logging;provider=paxlogging;version="5.5.28",
               org.apache.avalon.framework.logger;uses:="org.apache.log";provider=paxlogging;version="4.3",
-              org.ops4j.pax.logging.avalon;uses:="org.apache.avalon.framework.logger,org.ops4j.pax.logging";provider=paxlogging;version="2.2.7",
-              org.jboss.logging;provider=paxlogging;version="3.4.1.Final",
+              org.ops4j.pax.logging.avalon;uses:="org.apache.avalon.framework.logger,org.ops4j.pax.logging";provider=paxlogging;version="2.2.12",
+              org.jboss.logging;provider=paxlogging;version="3.6.3.Final",
+              org.jboss.logging;provider=paxlogging;version="3.5.3.Final",
+              org.jboss.logging;provider=paxlogging;version="3.4.3.Final",
               org.jboss.logging;provider=paxlogging;version="3.3.0.Final",
               org.knopflerfish.service.log;uses:="org.osgi.framework,org.osgi.service.log";provider=paxlogging;version="1.2.0",
               org.knopflerfish.service.log;provider=paxlogging;version="1.1.0",
-              org.ops4j.pax.logging;uses:="org.knopflerfish.service.log,org.osgi.framework,org.osgi.service.log,org.osgi.util.tracker";provider=paxlogging;version="2.2.7",
-              org.ops4j.pax.logging.spi;provider=paxlogging;version="2.2.7",
-              org.osgi.service.log;uses:="org.osgi.framework";version="1.4"
+              org.ops4j.pax.logging;uses:="org.knopflerfish.service.log,org.osgi.framework,org.osgi.service.log,org.osgi.util.tracker";provider=paxlogging;version="2.2.12",
+              org.ops4j.pax.logging.spi;uses:="org.osgi.service.log";provider=paxlogging;version="2.2.12",
+              org.osgi.service.log;uses:="org.osgi.framework";version="1.5"
             </Export-Package>
 
             <Import-Package>


### PR DESCRIPTION
It also updates export versions to mimic the original 2.2.12 artifact

@pentaho/tatooine_dev 